### PR TITLE
use openjdk 8 instead of oracle jdk to build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 install:
   - mvn --settings .travis/mvnsettings.xml install -DskipTests=true -Dgpg.skip -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
The current error while building is due to an oracle jdk license issue. This PR changes the build image to use the openjdk 8.