### PR TITLE
Fix gpg generation script

### DIFF
--- a/.travis/gpg.sh
+++ b/.travis/gpg.sh
@@ -29,7 +29,7 @@ gpg --batch --gen-key gen-key-script
 # uid                  Lars K.W. Gohlke <lars.gohlke@idealo.de>
 # ssb   4096R/CC1613B2 2016-09-08
 # ssb   4096R/55B7CAA2 2016-09-08
-export GPG_KEYNAME=$(gpg -K | grep ^sec | cut -d/  -f2 | cut -d\  -f1 | head -n1)
+export GPG_KEYNAME=$(gpg -K | grep ^\\s | head -n1)
 
 # cleanup local configuration
 shred gen-key-script


### PR DESCRIPTION
`gpg -K` format has changed, is now:
```
sec   rsa4096 2019-11-02 [SCEA]
      CBB24AEA43C4BF85BEB4173A04741BD34B0285B4
uid           [ultimate] CurrencyFair <tech@currencyfair.com>
```
the `CBB24AEA43C4BF85BEB4173A04741BD34B0285B4` is the key id we need.