### PR TITLE
Adds `external_id` to the Notification class to be used for idempotency

### DIFF
--- a/src/main/java/com/currencyfair/onesignal/model/notification/Notification.java
+++ b/src/main/java/com/currencyfair/onesignal/model/notification/Notification.java
@@ -724,6 +724,9 @@ public class Notification {
     @JsonProperty("isChrome")
     private Boolean chrome;
 
+    @JsonProperty("external_id")
+    private String externalId;
+
     public String getId() {
         return id;
     }
@@ -1215,6 +1218,12 @@ public class Notification {
     public Boolean getChrome() {
         return chrome;
     }
+
+    public void setExternalId(String string) {
+        this.externalId = string;
+    }
+
+    public String getExternalId() { return this.externalId; }
 
     public void setChrome(Boolean chrome) {
         this.chrome = chrome;

--- a/src/main/java/com/currencyfair/onesignal/model/notification/Notification.java
+++ b/src/main/java/com/currencyfair/onesignal/model/notification/Notification.java
@@ -724,6 +724,11 @@ public class Notification {
     @JsonProperty("isChrome")
     private Boolean chrome;
 
+    /**
+     * A request received with this parameter will first look for another notification with the same external_id.
+     * If one exists, a notification will not be sent, and result of the previous operation will instead be returned.
+     * Therefore, if you plan on using this feature, it's important to use a good source of randomness to generate the UUID passed here.
+     */
     @JsonProperty("external_id")
     private String externalId;
 
@@ -1223,7 +1228,9 @@ public class Notification {
         this.externalId = string;
     }
 
-    public String getExternalId() { return this.externalId; }
+    public String getExternalId() {
+        return this.externalId;
+    }
 
     public void setChrome(Boolean chrome) {
         this.chrome = chrome;


### PR DESCRIPTION
A request received with this parameter will first look for another notification with the same external_id. If one exists, a notification will not be sent, and result of the previous operation will instead be returned. Therefore, if you plan on using this feature, it's important to use a good source of randomness to generate the UUID passed here.