### PR TITLE
Update nexus plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
         <maven-site-plugin.version>3.6</maven-site-plugin.version>
         <maven-jxr-plugin.version>2.5</maven-jxr-plugin.version>
-        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
     </properties>
 


### PR DESCRIPTION
This PR updates `nexus-staging-maven-plugin` to the latest and tries to fix the travis deployment step where [public key was not found ](https://travis-ci.org/github/CurrencyFair/OneSignal-Java-SDK/builds/642008357) during the execution of nexus-staging-maven-plugin. It could be verified from the deployment result.