### PR TITLE
Try to fix gpg key not found on ubuntu keyserver

### DIFF
--- a/.github/workflows/gpg.sh
+++ b/.github/workflows/gpg.sh
@@ -29,8 +29,8 @@ gpg --batch --gen-key gen-key-script
 # uid                  Lars K.W. Gohlke <lars.gohlke@idealo.de>
 # ssb   4096R/CC1613B2 2016-09-08
 # ssb   4096R/55B7CAA2 2016-09-08
-gpg -K --keyid-format=short
-export GPG_KEYNAME=$(gpg -K --keyid-format=short | grep ^sec | cut -d/  -f2 | cut -d\  -f1 | head -n1)
+gpg -K --keyid-format=0xshort
+export GPG_KEYNAME=$(gpg -K --keyid-format=0xshort | grep ^sec | cut -d/  -f2 | cut -d\  -f1 | head -n1)
 
 # cleanup local configuration
 shred gen-key-script
@@ -48,5 +48,9 @@ while(true); do
   date
   GNUPGHOME=./gpgtest gpg --keyserver keyserver.ubuntu.com  --recv-keys ${GPG_KEYNAME} && break || sleep 30
 done
+
+echo "Waiting for 2 minutes to let the key being synced"
+sleep 120
+
 echo "Key ${GPG_KEYNAME} uploaded to keyserver.ubuntu.com"
 rm -rf ./gpgtest

--- a/.github/workflows/mvnsettings.xml
+++ b/.github/workflows/mvnsettings.xml
@@ -18,6 +18,7 @@
                 <activeByDefault>true</activeByDefault>
             </activation>
             <properties>
+                <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
                 <gpg.executable>gpg</gpg.executable>
                 <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
             </properties>


### PR DESCRIPTION
This PR tries to solve gpg key unable to be located issue on keyserver.ubuntu.com during release.

From this [sonatype doc](https://central.sonatype.org/publish/publish-maven/#gpg-signed-components), the recommended key-id format is `0xshort` which will be passed to the maven plugin to locate the key.

Second this [working example](https://github.com/idealo/logback-redis/blob/25ea69857d86646e5a0dfe5eefe81431c508c1b5/.travis/settings.xml#L20), `${env.GPG_KEYNAME}` should be passed to mvn settings.xml. In addition to the keyname, a 2-min wait time is added to let the key being synced.