### PR TITLE
Remove deprecated fields on notification endpoint response payloads

### DIFF
--- a/src/main/java/com/currencyfair/onesignal/model/notification/CreateNotificationResponse.java
+++ b/src/main/java/com/currencyfair/onesignal/model/notification/CreateNotificationResponse.java
@@ -28,11 +28,6 @@ public class CreateNotificationResponse {
     private String id;
 
     /**
-     * Number of recipients that receive the notification.
-     */
-    private Integer recipients;
-
-    /**
      * Not strictly defined so treating it dynamically... No smart mapping to a class can be done since errors content
      * can be an array of strings (as error messages) or a JSON object (as "invalid_player_ids").
      */
@@ -44,14 +39,6 @@ public class CreateNotificationResponse {
 
     public void setId(String id) {
         this.id = id;
-    }
-
-    public Integer getRecipients() {
-        return recipients;
-    }
-
-    public void setRecipients(Integer recipients) {
-        this.recipients = recipients;
     }
 
     public Object getErrors() {

--- a/src/main/java/com/currencyfair/onesignal/model/notification/ViewNotificationResponse.java
+++ b/src/main/java/com/currencyfair/onesignal/model/notification/ViewNotificationResponse.java
@@ -31,12 +31,6 @@ public class ViewNotificationResponse extends Notification {
     private Long successful;
 
     /**
-     * Number of notifications that have not been sent out yet. This can mean either our system is still processing the
-     * notification or you have delayed options set.
-     */
-    private Long remaining;
-
-    /**
      * Number of notifications that could not be delivered due to an error. You can find more information by viewing
      * the notification in the dashboard.
      */
@@ -76,14 +70,6 @@ public class ViewNotificationResponse extends Notification {
 
     public void setSuccessful(Long successful) {
         this.successful = successful;
-    }
-
-    public Long getRemaining() {
-        return remaining;
-    }
-
-    public void setRemaining(Long remaining) {
-        this.remaining = remaining;
     }
 
     public Long getFailed() {


### PR DESCRIPTION
See BAU-2973 ticket
OneSignal sent a deprecation notice for 2 fields via email https://deal.town/onesignal/api-deprecation---action-may-be-needed-to-prevent-disruption-PKJ73FYT28

This removes:
- The `recipients` field from the POST response from [`/api/v1/notification`](https://documentation.onesignal.com/reference/create-notification)
- The `remaining` field from the GET response from [`/api/v1/notification/{id}`](https://documentation.onesignal.com/reference/view-notification) and [`/api/v1/notifications`](https://documentation.onesignal.com/reference/view-notifications)
