### PR TITLE
Fix gpg key deletion in CI workflow

### DIFF
--- a/.github/workflows/deploy.sh
+++ b/.github/workflows/deploy.sh
@@ -12,7 +12,7 @@ fi
 
 # cleanup and generate gpg keys
 if [ -d "$HOME/.gnupg" ]; then
-    shred -v ~/.gnupg/*
+    find ~/.gnupg/ -type f -exec shred -v {} \;
     rm -rf ~/.gnupg
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.currencyfair</groupId>
     <artifactId>onesignal</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.18-SNAPSHOT</version>
 
     <name>OneSignal Java SDK</name>
     <description>OneSignal Java SDK is a java library enabling easy usage of OneSignal REST API</description>


### PR DESCRIPTION
This fixes publishing new versions of the library. Seems it was caused by newer versions of gpg adding subdirectories under `.gnupg/*`. The error in the logs was `shred: /home/runner/.gnupg/private-keys-v1.d: failed to open for writing: Is a directory`

example after the fix https://github.com/CurrencyFair/OneSignal-Java-SDK/actions/runs/4363782387/jobs/7630293337 for `1.0.18-SNAPSHOT` https://oss.sonatype.org/#nexus-search;quick~com.currencyfair https://oss.sonatype.org/content/repositories/snapshots/com/currencyfair/onesignal/1.0.18-SNAPSHOT/